### PR TITLE
Small package.json improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/grapesjs-blocks-basic.min.js",
   "scripts": {
     "lint": "eslint src",
-    "build": "WEBPACK_ENV=prod && npm run v:patch && webpack",
+    "build": "cross-env WEBPACK_ENV=prod && npm run v:patch && webpack",
     "v:patch": "npm version --no-git-tag-version patch",
-    "start": "WEBPACK_ENV=dev ./node_modules/.bin/webpack-dev-server --progress --colors"
+    "start": "cross-env WEBPACK_ENV=dev ./node_modules/.bin/webpack-dev-server --progress --colors"
   },
   "keywords": [
     "grapesjs",
@@ -17,12 +17,15 @@
   ],
   "author": "Artur Arseniev",
   "license": "BSD-3-Clause",
+  "dependency": {
+    "grapesjs": "^0.8.4"
+  },
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",
-    "grapesjs": "^0.8.4",
-    "jquery": "^3.2.1",
+    "cross-env": "^5.0.5",
+    "jquery": "^3.1.1",
     "node-sass": "^4.5.3",
     "webpack": "^2.6.1",
     "webpack-dev-server": "^2.4.5"


### PR DESCRIPTION
- Use `cross-env` to set ENV variables
- Put GrapesJS as an actual dependency (not a dev one)
- Downgrade required JQuery to one required by Grapes