### PR TITLE
Typo Error on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ npm i
 The plugin relies on GrapesJS via `peerDependencies` so you have to install it manually (without adding it to package.json)
 
 ```sh
-$ npm i grapesjs --no-save
+$ npm i grapesjs-blocks-basic --no-save
 ```
 
 Start the dev server


### PR DESCRIPTION
Basic Typo error in the documentation (line 95) README.md
```
npm i grapesjs --no-save 
```
to
```
npm i grapesjs-blocks-basic --no-save
```